### PR TITLE
feat: Renovateの設定を更新して依存関係のpinを有効化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
+  "extends": [
+    "config:best-practices",
+    ":pinAllExceptPeerDependencies"
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
## 概要
Renovateの設定を更新して、依存関係のpinを有効化しました。

## 変更内容
- `config:pinAllExceptPeerDependencies`をextendsに追加
- ピア依存関係以外の依存関係をpinするように設定
- より予測可能なビルド環境を実現

## 技術的詳細
- `:pinAllExceptPeerDependencies`は、ピア依存関係を除くすべての依存関係をpinします
- これにより、依存関係のバージョンが固定され、ビルドの再現性が向上します
- 既存のpackageRulesの設定は維持されており、pin PRは自動マージされます

## 影響範囲
- 依存関係の管理方法が変更されます
- 将来的にRenovateがpin PRを作成するようになります
- ビルドの安定性が向上します

## テスト
- TypeScriptの型チェックが正常に完了
- Prettierによるフォーマットが適用済み