### PR TITLE
ロゴフォントをMochiy Pop Oneに変更

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import {
 	mantineHtmlProps,
 } from "@mantine/core";
 import type { Metadata } from "next";
+import { mochiyPopOne } from "@/lib/fonts";
 import { theme } from "@/lib/theme";
 import "./global.css";
 
@@ -20,7 +21,7 @@ export default function RootLayout({
 	children: React.ReactNode;
 }) {
 	return (
-		<html lang="ja" {...mantineHtmlProps}>
+		<html lang="ja" {...mantineHtmlProps} className={mochiyPopOne.variable}>
 			<head>
 				<ColorSchemeScript />
 			</head>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import {
 	Box,
 	Button,
+	Center,
 	Container,
 	Image,
 	Stack,
@@ -30,11 +31,18 @@ export default function RootPage() {
 						clipPath: "inset(0 round 0 0 30px 0)",
 					}}
 				>
-					<Box pt="md" px="md">
-						<Text component={NextLink} href="/" c="green.1" size="sm" fw={700}>
+					<Center pt="md" px="md">
+						<Text
+							component={NextLink}
+							href="/"
+							c="white"
+							size="xl"
+							fw={400}
+							style={{ fontFamily: "var(--font-mochiy-pop-one)" }}
+						>
 							ワリーリ
 						</Text>
-					</Box>
+					</Center>
 					<Container py="50px">
 						<Image
 							component={NextImage}

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, Title } from "@mantine/core";
+import { Box, Center, Text, Title } from "@mantine/core";
 import NextLink from "next/link";
 
 export function PageHeader({ title }: { title: string }) {
@@ -11,10 +11,19 @@ export function PageHeader({ title }: { title: string }) {
 					clipPath: "inset(0 round 0 0 30px 0)",
 				}}
 			>
-				<Box pt="md" px="md">
-					<Text component={NextLink} href="/" c="green.1" size="sm" fw={700}>
-						ワリーリ
-					</Text>
+				<Box pt="md" px="xl">
+					<Center>
+						<Text
+							component={NextLink}
+							href="/"
+							c="white"
+							size="xl"
+							fw={400}
+							ff="var(--font-mochiy-pop-one)"
+						>
+							ワリーリ
+						</Text>
+					</Center>
 					<Box pt="md" pb="lg">
 						<Title order={1} size="h3" c="white">
 							{title}

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,9 @@
+import { Mochiy_Pop_One } from "next/font/google";
+
+export const mochiyPopOne = Mochiy_Pop_One({
+	weight: "400",
+	subsets: ["latin"],
+	display: "swap",
+	preload: true,
+	variable: "--font-mochiy-pop-one",
+});


### PR DESCRIPTION
## 概要
アプリケーションのロゴフォントをより親しみやすいMochiy Pop Oneフォントに変更しました。このフォントは手書き風でポップなデザインが特徴で、「ワリーリ」ブランドにより適したビジュアルアイデンティティを提供します。

## 変更内容
- **新規ファイル**: `lib/fonts.ts` - Mochiy Pop One Google Fontの設定を追加
- **更新**: `app/layout.tsx` - フォント設定とCSS変数の適用
- **更新**: `components/page-header.tsx` - ページヘッダーのロゴテキストにフォント適用
- **更新**: `app/page.tsx` - メインページのロゴテキストにフォント適用

## 技術仕様
- Google FontsのMochiy Pop Oneフォントを使用
- Next.jsのフォント最適化機能（`next/font/google`）を活用
- `display: 'swap'`と`preload: true`でパフォーマンスを最適化
- CSS変数（`--font-mochiy-pop-one`）で一元管理

## デザイン変更
- フォントサイズを`lg`から`xl`に拡大
- フォントウェイトを400に統一
- ロゴテキストをセンタリング表示に変更
- 色を白色（`white`）に統一